### PR TITLE
feat: Razer Viper Ultimate support — battery, DPI, system tray

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Synaptix is a Rust-powered daemon and GUI that brings first-class Razer hardware
 ### 🧪 Quality
 - **Strictly TDD** — every layer (protocol types, daemon logic, USB payload math, React components) built test-first
 - **CI pipeline** — `cargo test`, `clippy -D warnings`, `cargo fmt`, and WebDriver E2E tests on every push
-- **42 Rust unit tests** across daemon and protocol crates
+- **78+ Rust unit tests** across daemon and protocol crates
 
 ---
 
@@ -389,8 +389,10 @@ Synaptix supports **219+ Razer peripherals** across mice, keyboards, and headset
 | Device | Type | PID(s) | Static RGB | DPI Control | Battery Reporting |
 |---|---|---|---|---|---|
 | Razer Cobra Pro | Mouse | `0x00AF` (wired) · `0x00B0` (wireless) | ✅ Tested | ✅ Tested | ✅ Tested |
+| Razer Viper Ultimate | Mouse | `0x007A` (wired) · `0x007B` (wireless dongle) | ✅ Tested | ✅ Tested | ✅ Tested |
 | Razer DeathAdder V2 Pro | Mouse | `0x007C` (wired) · `0x007D` (wireless) | ✅ Implemented | 🔄 Untested | 🔄 Untested |
 | Razer Kraken V4 Pro | Headset | `0x0568` (USB hub) · `0x056C` (audio) | N/A | N/A | ✅ Tested |
+| Razer BlackWidow V3 Mini HyperSpeed | Keyboard | `0x0258` (wired) · `0x0271` (wireless) | ✅ Tested | N/A | ✅ Tested |
 
 **Legend:** ✅ Verified on real hardware &nbsp;|&nbsp; 🔄 Protocol mapped, needs hardware confirmation &nbsp;|&nbsp; N/A Not applicable
 

--- a/crates/synaptix-daemon/src/device_manager.rs
+++ b/crates/synaptix-daemon/src/device_manager.rs
@@ -9,12 +9,17 @@ use synaptix_protocol::{
 fn lighting_params(product_id: &RazerProductId) -> (u8, u8) {
     use crate::razer_protocol::{
         LED_BACKLIGHT, LED_ZERO, TRANSACTION_ID_COBRA, TRANSACTION_ID_DA,
-        TRANSACTION_ID_KEYBOARD_WIRELESS,
+        TRANSACTION_ID_KEYBOARD_WIRELESS, TRANSACTION_ID_VIPER,
     };
     match product_id {
         // Cobra Pro / Basilisk V3 Pro group: transaction_id=0x1F, ZERO_LED
         RazerProductId::CobraProWired | RazerProductId::CobraProWireless => {
             (TRANSACTION_ID_COBRA, LED_ZERO)
+        }
+        // Viper Ultimate: transaction_id=0xFF, ZERO_LED
+        // Source: razermouse_driver.c — Viper Ultimate uses txn_id 0xFF
+        RazerProductId::ViperUltimateWired | RazerProductId::ViperUltimateWireless => {
+            (TRANSACTION_ID_VIPER, LED_ZERO)
         }
         // BlackWidow V3 Mini HyperSpeed Wired: transaction_id=0x1F, BACKLIGHT_LED
         // Ref: razerkbd_driver.c ~line 2107

--- a/crates/synaptix-daemon/src/main.rs
+++ b/crates/synaptix-daemon/src/main.rs
@@ -16,6 +16,13 @@ const COBRA_PRO_PIDS: &[(u16, ConnectionType)] = &[
     (0x00AF, ConnectionType::Wired),  // USB cable (charging / wired-only mode)
 ];
 
+// PIDs for the Viper Ultimate, dongle-first: when both are plugged in the
+// dongle is the active gaming connection and the cable is just charging.
+const VIPER_ULTIMATE_PIDS: &[(u16, ConnectionType)] = &[
+    (0x007B, ConnectionType::Dongle), // HyperSpeed dongle (wireless)
+    (0x007A, ConnectionType::Wired),  // USB cable (wired/charging mode)
+];
+
 // PIDs for the BlackWidow V3 Mini HyperSpeed.
 // Wireless (dongle) is preferred when both are present.
 // The wired variant (0x0258) is the keyboard charging via USB cable — it
@@ -50,6 +57,29 @@ fn detect_cobra_pro() -> (u16, RazerProductId, ConnectionType, String) {
         .unwrap_or_else(|| "Razer Cobra Pro".to_string());
 
     (pid, product_id, conn_type, name)
+}
+
+/// Probe USB for the Viper Ultimate (wired or wireless dongle).
+///
+/// Returns `None` when neither PID is found on the USB bus (device not connected).
+fn detect_viper_ultimate() -> Option<(u16, RazerProductId, ConnectionType, String)> {
+    let candidate_pids: Vec<u16> = VIPER_ULTIMATE_PIDS.iter().map(|(p, _)| *p).collect();
+    let found_pid = usb_backend::detect_connected_pid(&candidate_pids)?;
+
+    let (pid, conn_type) = VIPER_ULTIMATE_PIDS
+        .iter()
+        .find(|(cp, _)| *cp == found_pid)
+        .map(|(cp, ct)| (*cp, ct.clone()))?;
+
+    let product_id = match pid {
+        0x007A => RazerProductId::ViperUltimateWired,
+        _ => RazerProductId::ViperUltimateWireless,
+    };
+    let name = get_device_profile(pid)
+        .map(|p| p.name)
+        .unwrap_or_else(|| "Razer Viper Ultimate".to_string());
+
+    Some((pid, product_id, conn_type, name))
 }
 
 /// Probe USB for the BlackWidow V3 Mini HyperSpeed (wired or wireless).
@@ -197,6 +227,110 @@ async fn run_daemon(tx: std::sync::mpsc::Sender<TrayUpdate>) {
             connection_type: initial_conn,
         },
     );
+
+    // ── Viper Ultimate detection ──────────────────────────────────────────────
+    let detected_viper = tokio::task::spawn_blocking(detect_viper_ultimate)
+        .await
+        .unwrap_or(None);
+
+    // Battery config for Viper Ultimate: txn_id=0xFF (Viper receiver family),
+    // wait=59.9ms, wired companion=0x007A.
+    // `None` means no Viper Ultimate was detected.
+    let viper_battery_cfg: Option<(u16, u8, ConnectionType, Option<u16>)> = if let Some((
+        pid,
+        product_id,
+        conn_type,
+        name,
+    )) = &detected_viper
+    {
+        let pid = *pid;
+        if let Some(profile) = get_device_profile(pid) {
+            let device_id = "viper-ultimate".to_string();
+            log::info!(
+                "[Detect] {} on USB: PID={pid:#06x} conn={}",
+                profile.name,
+                conn_type.label()
+            );
+
+            // Startup battery: try up to 3 times.
+            let mut attempt = 0u8;
+            let initial_viper_battery = loop {
+                let pid_c = pid;
+                let conn_c = conn_type.clone();
+                let companion = if matches!(conn_type, ConnectionType::Dongle) {
+                    Some(usb_backend::VIPER_ULTIMATE_WIRED_PID)
+                } else {
+                    None
+                };
+                let result = tokio::task::spawn_blocking(move || {
+                    usb_backend::query_battery(
+                        pid_c,
+                        razer_protocol::TRANSACTION_ID_VIPER,
+                        razer_protocol::WAIT_VIPER_RECEIVER_US,
+                        &conn_c,
+                        companion,
+                    )
+                })
+                .await
+                .ok()
+                .and_then(|r| r.ok());
+
+                match result {
+                    Some(state) => break state,
+                    None => {
+                        attempt += 1;
+                        if attempt >= 3 {
+                            log::warn!("[ViperBatt] Startup query failed after 3 attempts — defaulting to Unknown.");
+                            break BatteryState::Unknown;
+                        }
+                        log::warn!(
+                            "[ViperBatt] Startup attempt {attempt} failed, retrying in 500ms…"
+                        );
+                        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+                    }
+                }
+            };
+
+            log::info!("[ViperBatt] Startup state: {initial_viper_battery:?}");
+
+            manager.add_device(
+                device_id.clone(),
+                RazerDevice {
+                    name: name.clone(),
+                    product_id: product_id.clone(),
+                    battery_state: initial_viper_battery.clone(),
+                    capabilities: profile.capabilities,
+                    connection_type: conn_type.clone(),
+                },
+            );
+
+            // Push startup battery to tray.
+            let (pct, is_charging) = battery_to_pct(&initial_viper_battery);
+            tx.send(TrayUpdate {
+                device_id,
+                device_name: name.clone(),
+                percentage: pct,
+                is_charging,
+            })
+            .ok();
+
+            let companion = if matches!(conn_type, ConnectionType::Dongle) {
+                Some(usb_backend::VIPER_ULTIMATE_WIRED_PID)
+            } else {
+                None
+            };
+            Some((
+                pid,
+                razer_protocol::TRANSACTION_ID_VIPER,
+                conn_type.clone(),
+                companion,
+            ))
+        } else {
+            None
+        }
+    } else {
+        None
+    };
 
     // Probe for known headsets on the USB bus.
     // 0x0568 = Kraken V4 Pro OLED Hub (always present when the headset is plugged in).
@@ -520,6 +654,75 @@ async fn run_daemon(tx: std::sync::mpsc::Sender<TrayUpdate>) {
                 }
 
                 tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
+            }
+        });
+    }
+
+    // ── Viper Ultimate battery polling loop (every 60 s) ─────────────────────
+    if let Some((viper_pid, viper_txn, viper_conn_type, viper_companion)) = viper_battery_cfg {
+        let viper_conn = conn.clone();
+        let viper_tx = tx.clone();
+        let viper_display_name = detected_viper
+            .as_ref()
+            .map(|(_, _, _, n)| n.clone())
+            .unwrap_or_else(|| "Razer Viper Ultimate".to_string());
+
+        tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+
+            loop {
+                let ct = viper_conn_type.clone();
+                let result = tokio::task::spawn_blocking(move || {
+                    usb_backend::query_battery(
+                        viper_pid,
+                        viper_txn,
+                        razer_protocol::WAIT_VIPER_RECEIVER_US,
+                        &ct,
+                        viper_companion,
+                    )
+                })
+                .await
+                .ok()
+                .and_then(|r| r.ok());
+
+                if let Some(new_state) = result {
+                    let state_json = serde_json::to_string(&new_state)
+                        .unwrap_or_else(|_| "\"Unknown\"".to_string());
+                    let (pct, is_charging) = battery_to_pct(&new_state);
+
+                    if let Ok(iface_ref) = viper_conn
+                        .object_server()
+                        .interface::<_, DeviceManager>("/org/synaptix/Daemon")
+                        .await
+                    {
+                        {
+                            let mut iface = iface_ref.get_mut().await;
+                            iface.update_battery("viper-ultimate", new_state.clone());
+                        }
+                        DeviceManager::battery_changed(
+                            iface_ref.signal_emitter(),
+                            "viper-ultimate",
+                            &state_json,
+                        )
+                        .await
+                        .ok();
+                    }
+
+                    viper_tx
+                        .send(TrayUpdate {
+                            device_id: "viper-ultimate".to_string(),
+                            device_name: viper_display_name.clone(),
+                            percentage: pct,
+                            is_charging,
+                        })
+                        .ok();
+
+                    log::info!("[ViperBatt] Poll: viper-ultimate → {new_state:?}");
+                } else {
+                    log::warn!("[ViperBatt] Battery query failed for PID=0x{viper_pid:04x} — device may be off or out of range.");
+                }
+
+                tokio::time::sleep(tokio::time::Duration::from_secs(60)).await;
             }
         });
     }

--- a/crates/synaptix-daemon/src/razer_protocol.rs
+++ b/crates/synaptix-daemon/src/razer_protocol.rs
@@ -29,6 +29,10 @@ pub const TRANSACTION_ID_DA: u8 = 0x3F;
 /// Transaction ID for Cobra Pro, Basilisk V3 Pro, and newer wireless mice.
 pub const TRANSACTION_ID_COBRA: u8 = 0x1F;
 
+/// Transaction ID for Viper Ultimate and similar wireless mice.
+/// Source: `razermouse_driver.c` — charge_level switch for Viper Ultimate PIDs.
+pub const TRANSACTION_ID_VIPER: u8 = 0xFF;
+
 /// Transaction ID for wireless keyboards (BlackWidow V3 Mini HyperSpeed Wireless, etc.).
 /// Source: `razerkbd_driver.c` — charge_level switch for `_WIRELESS` PIDs.
 pub const TRANSACTION_ID_KEYBOARD_WIRELESS: u8 = 0x9F;
@@ -50,7 +54,7 @@ pub const WAIT_NEW_RECEIVER_US: u64 = 31_000;
 
 /// Minimum sleep (µs) for Viper Ultimate, DA V2 Pro, Viper V3 Pro, and Viper receivers.
 /// Source: `RAZER_VIPER_MOUSE_RECEIVER_WAIT_MIN_US` in razermouse_driver.h
-pub const _WAIT_VIPER_RECEIVER_US: u64 = 59_900;
+pub const WAIT_VIPER_RECEIVER_US: u64 = 59_900;
 
 /// Backlight LED zone — covers the logo on DA V2 Pro and similar mice.
 pub const LED_BACKLIGHT: u8 = 0x05;

--- a/crates/synaptix-daemon/src/usb_backend.rs
+++ b/crates/synaptix-daemon/src/usb_backend.rs
@@ -11,6 +11,10 @@ use synaptix_protocol::{registry::get_device_profile, BatteryState, ConnectionTy
 /// cable is plugged in even when the active connection is via the dongle.
 pub const COBRA_PRO_WIRED_PID: u16 = 0x00AF;
 
+/// PID of the Viper Ultimate wired interface (USB cable). Used to detect whether
+/// the cable is plugged in when the mouse is in wireless mode.
+pub const VIPER_ULTIMATE_WIRED_PID: u16 = 0x007A;
+
 /// PID of the BlackWidow V3 Mini HyperSpeed wired interface. Used to detect
 /// whether the USB cable is plugged in when the keyboard is in wireless mode.
 pub const BLACKWIDOW_V3_MINI_WIRED_PID: u16 = 0x0258;

--- a/crates/synaptix-protocol/src/lib.rs
+++ b/crates/synaptix-protocol/src/lib.rs
@@ -6,13 +6,14 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RazerProductId {
     // Mice
-    DeathAdderV2Pro,  // 0x007C
-    MambaWireless,    // 0x0073
-    ViperUltimate,    // 0x007A
-    BasiliskUltimate, // 0x0085
-    NagaPro,          // 0x008F
-    CobraProWired,    // 0x00AF
-    CobraProWireless, // 0x00B0
+    DeathAdderV2Pro,       // 0x007C
+    MambaWireless,         // 0x0073
+    ViperUltimateWired,    // 0x007A
+    ViperUltimateWireless, // 0x007B
+    BasiliskUltimate,      // 0x0085
+    NagaPro,               // 0x008F
+    CobraProWired,         // 0x00AF
+    CobraProWireless,      // 0x00B0
     // Headsets
     KrakenUltimate, // 0x0527
     KrakenKittyV2,  // 0x0560 (Razer Kraken Kitty V2)
@@ -99,7 +100,8 @@ impl RazerProductId {
         match self {
             RazerProductId::DeathAdderV2Pro => 0x007C,
             RazerProductId::MambaWireless => 0x0073,
-            RazerProductId::ViperUltimate => 0x007A,
+            RazerProductId::ViperUltimateWired => 0x007A,
+            RazerProductId::ViperUltimateWireless => 0x007B,
             RazerProductId::BasiliskUltimate => 0x0085,
             RazerProductId::NagaPro => 0x008F,
             RazerProductId::CobraProWired => 0x00AF,

--- a/crates/synaptix-protocol/src/registry.rs
+++ b/crates/synaptix-protocol/src/registry.rs
@@ -444,13 +444,13 @@ pub fn get_device_profile(product_id: u16) -> Option<DeviceProfile> {
             "Razer Viper Ultimate (Wired)",
             DeviceType::Mouse,
             false,
-            false,
+            true, // DPI supported via USB cable
         ),
         0x007B => (
             "Razer Viper Ultimate (Wireless)",
             DeviceType::Mouse,
-            true,
-            false,
+            true, // wireless — reports battery via dongle
+            true, // DPI supported
         ),
         0x00A5 => (
             "Razer Viper V2 Pro (Wired)",
@@ -1472,5 +1472,47 @@ mod tests {
             );
             assert_eq!(profile.control_interface, 0);
         }
+    }
+
+    // ── Viper Ultimate TDD tests ─────────────────────────────────────────────
+
+    #[test]
+    fn test_viper_ultimate_wired_has_dpi_no_battery() {
+        let profile =
+            get_device_profile(0x007A).expect("Viper Ultimate (Wired) must be in registry");
+        assert_eq!(profile.name, "Razer Viper Ultimate (Wired)");
+        assert_eq!(profile.device_type, DeviceType::Mouse);
+        assert_eq!(profile.product_id, 0x007A);
+        assert_eq!(profile.control_interface, 0);
+        assert!(
+            profile.capabilities.contains(&DeviceCapability::DpiControl),
+            "Viper Ultimate Wired must advertise DpiControl"
+        );
+        assert!(
+            !profile
+                .capabilities
+                .contains(&DeviceCapability::BatteryReporting),
+            "Viper Ultimate Wired (USB cable) must NOT advertise BatteryReporting"
+        );
+    }
+
+    #[test]
+    fn test_viper_ultimate_wireless_has_battery_and_dpi() {
+        let profile =
+            get_device_profile(0x007B).expect("Viper Ultimate (Wireless) must be in registry");
+        assert_eq!(profile.name, "Razer Viper Ultimate (Wireless)");
+        assert_eq!(profile.device_type, DeviceType::Mouse);
+        assert_eq!(profile.product_id, 0x007B);
+        assert_eq!(profile.control_interface, 0);
+        assert!(
+            profile
+                .capabilities
+                .contains(&DeviceCapability::BatteryReporting),
+            "Viper Ultimate Wireless must advertise BatteryReporting"
+        );
+        assert!(
+            profile.capabilities.contains(&DeviceCapability::DpiControl),
+            "Viper Ultimate Wireless must advertise DpiControl"
+        );
     }
 }

--- a/crates/synaptix-ui/src/components/DeviceCard.test.tsx
+++ b/crates/synaptix-ui/src/components/DeviceCard.test.tsx
@@ -316,3 +316,66 @@ describe("DeviceCard: wired keyboard shows battery ring (has BatteryReporting)",
     expect(screen.getByLabelText("Battery level unknown")).toBeInTheDocument();
   });
 });
+
+// ── Viper Ultimate ──────────────────────────────────────────────────────────
+// Wireless Viper Ultimate: battery ring + DPI capability.
+// Wired Viper Ultimate: no battery ring, but DPI capability.
+
+const VIPER_ULTIMATE_WIRELESS: RazerDevice = {
+  device_id: "viper-ultimate",
+  name: "Razer Viper Ultimate (Wireless)",
+  product_id: "ViperUltimateWireless",
+  battery_state: { Discharging: 80 },
+  capabilities: ["BatteryReporting", "DpiControl", { Lighting: "Off" }],
+  connection_type: "Dongle",
+};
+
+const VIPER_ULTIMATE_WIRED: RazerDevice = {
+  device_id: "viper-ultimate",
+  name: "Razer Viper Ultimate (Wired)",
+  product_id: "ViperUltimateWired",
+  battery_state: "Unknown",
+  capabilities: ["DpiControl", { Lighting: "Off" }],
+  connection_type: "Wired",
+};
+
+describe("DeviceCard: Viper Ultimate Wireless — battery ring visible", () => {
+  beforeEach(() => {
+    vi.mocked(invoke).mockResolvedValue([VIPER_ULTIMATE_WIRELESS]);
+    vi.mocked(listen).mockImplementation(() =>
+      Promise.resolve(() => { /* no-op unlisten */ }),
+    );
+  });
+
+  it("renders device name and battery percentage for wireless variant", async () => {
+    render(<MemoryRouter><App /></MemoryRouter>);
+
+    await waitFor(() =>
+      expect(screen.getByText("Razer Viper Ultimate (Wireless)")).toBeInTheDocument(),
+    );
+
+    expect(screen.getByText("80%")).toBeInTheDocument();
+    expect(screen.queryByText("?")).not.toBeInTheDocument();
+  });
+});
+
+describe("DeviceCard: Viper Ultimate Wired — no battery ring", () => {
+  beforeEach(() => {
+    vi.mocked(invoke).mockResolvedValue([VIPER_ULTIMATE_WIRED]);
+    vi.mocked(listen).mockImplementation(() =>
+      Promise.resolve(() => { /* no-op unlisten */ }),
+    );
+  });
+
+  it("renders device name without battery ring for wired variant", async () => {
+    render(<MemoryRouter><App /></MemoryRouter>);
+
+    await waitFor(() =>
+      expect(screen.getByText("Razer Viper Ultimate (Wired)")).toBeInTheDocument(),
+    );
+
+    expect(screen.queryByText("?")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Battery level unknown")).not.toBeInTheDocument();
+    expect(screen.queryByText(/%/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Implements full support for the Razer Viper Ultimate (wired and wireless dongle) — battery reporting, DPI control, and system tray integration. Behaviour matches the existing Cobra Pro implementation.

Closes #8

---

## 🖱️ Device Support

| PID | Variant | Battery | DPI | txn_id |
|-----|---------|---------|-----|--------|
| `0x007A` | Viper Ultimate (Wired) | ✗ USB-powered | ✓ | `0xFF` |
| `0x007B` | Viper Ultimate (Wireless) | ✓ | ✓ | `0xFF` |

**Protocol source:** `razermouse_driver.c` — Viper receiver family uses `txn_id=0xFF` and `RAZER_VIPER_MOUSE_RECEIVER_WAIT_MIN_US=59900µs`.

---

## 🔋 Battery

- Startup query (3 retries, 500ms apart) so tray + UI show real data immediately
- 60s polling loop → D-Bus `BatteryChanged` signal + system tray push
- Wired companion detection (`0x007A`) for charging state inference (same pattern as Cobra Pro)
- Sysfs fast-path via `razermouse` kernel module if bound (avoids libusb conflict)

## 🎯 DPI

- Full DPI support via existing `DpiControl.tsx` (preset buttons + custom input)
- DPI auto-persisted to `~/.config/synaptix/devices.json` and re-applied on daemon restart
- Command: class `0x04`, id `0x05`, txn_id `0xFF`

## 📊 System Tray

- Viper Ultimate appears in tray menu alongside Cobra Pro and keyboard
- Shows battery % and charging state in real time

---

## ✅ Tests (TDD — all green)

| Suite | Before | After |
|-------|--------|-------|
| Protocol (Rust) | 24 | **26** (+2 Viper Ultimate registry tests) |
| Daemon (Rust) | 52 | **52** |
| UI (Vitest) | 22 | **24** (+2: wireless battery ring, wired no battery ring) |

- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅
- Trivy: 1 pre-existing MEDIUM in transitive `glib` dep ✅