### PR TITLE
feat: Razer Kraken V4 Pro — haptic sensitivity + battery charging state (issue #11)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.2.0"
+version = "1.7.0"
 edition = "2021"
 authors = ["Eduardo Zenardi"]
 license = "MIT"

--- a/crates/synaptix-daemon/src/config.rs
+++ b/crates/synaptix-daemon/src/config.rs
@@ -6,6 +6,11 @@ fn config_path() -> Option<PathBuf> {
     directories::BaseDirs::new().map(|b| b.config_dir().join("synaptix").join("devices.json"))
 }
 
+/// Returns `~/.config/synaptix/headset_state.json`.
+fn headset_state_path() -> Option<PathBuf> {
+    directories::BaseDirs::new().map(|b| b.config_dir().join("synaptix").join("headset_state.json"))
+}
+
 /// Reads `devices.json` from disk. Returns an empty map on any error (file missing is fine).
 pub fn load_settings() -> HashMap<String, DeviceSettings> {
     let path = match config_path() {
@@ -61,6 +66,78 @@ pub fn save_settings(settings: &HashMap<String, DeviceSettings>) {
     }
 }
 
+/// Loads the persisted Kraken V4 Pro haptic level from disk.
+///
+/// Returns the saved level (0–100) or **33 (Low)** as a safe default when the
+/// file is absent. Never returns 0 as default — 0 would reset the hub's
+/// physical haptic setting to OFF on the first battery poll after daemon start.
+pub fn load_haptic_level() -> u8 {
+    let path = match headset_state_path() {
+        Some(p) => p,
+        None => return 33,
+    };
+
+    let json = match fs::read_to_string(&path) {
+        Ok(j) => j,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return 33,
+        Err(e) => {
+            log::warn!(
+                "[Config] Failed to read headset state {}: {e}",
+                path.display()
+            );
+            return 33;
+        }
+    };
+
+    match serde_json::from_str::<serde_json::Value>(&json) {
+        Ok(v) => {
+            let level = v["kraken_haptic_level"]
+                .as_u64()
+                .map(|n| n as u8)
+                .unwrap_or(33);
+            log::info!("[Config] Loaded persisted haptic level: {level}");
+            level
+        }
+        Err(e) => {
+            log::warn!("[Config] Failed to parse headset state: {e}");
+            33
+        }
+    }
+}
+
+/// Saves the Kraken V4 Pro haptic level to disk so it survives daemon restarts.
+///
+/// Called from `DeviceManager::set_haptic_intensity` after a successful USB write.
+pub fn save_haptic_level(level: u8) {
+    let path = match headset_state_path() {
+        Some(p) => p,
+        None => {
+            log::warn!("[Config] Could not resolve config directory — haptic level not saved");
+            return;
+        }
+    };
+
+    if let Some(dir) = path.parent() {
+        if let Err(e) = fs::create_dir_all(dir) {
+            log::error!(
+                "[Config] Failed to create config dir {}: {e}",
+                dir.display()
+            );
+            return;
+        }
+    }
+
+    let json = format!("{{\"kraken_haptic_level\":{level}}}");
+    if let Err(e) = fs::write(&path, &json) {
+        log::error!("[Config] Failed to write haptic level: {e}");
+    } else {
+        log::info!(
+            "[Config] Haptic level {level} persisted to {}",
+            path.display()
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -98,5 +175,56 @@ mod tests {
         assert_eq!(entry.dpi, Some(1800));
 
         std::fs::remove_file(tmp).ok();
+    }
+
+    /// load_haptic_level returns 33 when no file exists (safe non-zero default).
+    #[test]
+    fn test_load_haptic_level_default_when_absent() {
+        let level = load_haptic_level_from_path(
+            &std::env::temp_dir().join("synaptix_haptic_NONEXISTENT_test.json"),
+        );
+        assert_eq!(
+            level, 33,
+            "default must be 33, not 0 (0 would reset hub haptics)"
+        );
+    }
+
+    /// save_haptic_level + load round-trip.
+    #[test]
+    fn test_save_and_load_haptic_level() {
+        let tmp = std::env::temp_dir().join("synaptix_test_haptic_level.json");
+        save_haptic_level_to_path(100, &tmp);
+        let loaded = load_haptic_level_from_path(&tmp);
+        assert_eq!(loaded, 100);
+
+        save_haptic_level_to_path(33, &tmp);
+        assert_eq!(load_haptic_level_from_path(&tmp), 33);
+
+        save_haptic_level_to_path(0, &tmp);
+        assert_eq!(
+            load_haptic_level_from_path(&tmp),
+            0,
+            "level 0 (off) must round-trip correctly"
+        );
+
+        std::fs::remove_file(tmp).ok();
+    }
+
+    /// save_haptic_level_to_path / load_haptic_level_from_path for testable I/O.
+    fn save_haptic_level_to_path(level: u8, path: &std::path::Path) {
+        let json = format!("{{\"kraken_haptic_level\":{level}}}");
+        std::fs::write(path, &json).unwrap();
+    }
+
+    fn load_haptic_level_from_path(path: &std::path::Path) -> u8 {
+        match std::fs::read_to_string(path) {
+            Ok(json) => serde_json::from_str::<serde_json::Value>(&json)
+                .ok()
+                .and_then(|v| v["kraken_haptic_level"].as_u64())
+                .map(|n| n as u8)
+                .unwrap_or(33),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => 33,
+            Err(_) => 33,
+        }
     }
 }

--- a/crates/synaptix-daemon/src/device_manager.rs
+++ b/crates/synaptix-daemon/src/device_manager.rs
@@ -391,18 +391,14 @@ impl DeviceManager {
             if pid == 0x0568 {
                 // Kraken V4 Pro OLED Hub: 64-byte proprietary HID report on
                 // Interface 4, wValue=0x0202. Sets haptic sensitivity/amplification.
+                //
+                // NOTE: The motor vibrates in response to audio playing through
+                // the headset (routed by the kernel ALSA driver on Interface 2).
+                // We only control the sensitivity level here — the ALSA driver
+                // provides the audio source. Attempting to claim Interface 2 via
+                // libusb detaches the ALSA driver and mutes the headset.
                 let payload = crate::razer_protocol::build_haptic_report(clamped);
-                let sensitivity_result = crate::usb_backend::send_haptic_report(pid, &payload);
-
-                // Also send an audio-stream burst on Interface 2 so the haptic
-                // motor has a signal to convert into vibration.  This is a
-                // best-effort operation: the sensitivity command above is the
-                // authoritative result even if the burst fails.
-                if sensitivity_result.is_ok() && clamped > 0 {
-                    crate::usb_backend::send_haptic_audio_burst(pid);
-                }
-
-                sensitivity_result
+                crate::usb_backend::send_haptic_report(pid, &payload)
             } else {
                 // Legacy 90-byte Razer protocol for Kraken V3 HyperSense and
                 // other HapticFeedback-capable headsets.

--- a/crates/synaptix-daemon/src/device_manager.rs
+++ b/crates/synaptix-daemon/src/device_manager.rs
@@ -1,4 +1,8 @@
 use std::collections::HashMap;
+use std::sync::{
+    atomic::{AtomicU8, Ordering},
+    Arc,
+};
 use synaptix_protocol::{
     registry::{get_device_profile, DeviceCapability},
     BatteryState, DeviceSettings, LightingEffect, RazerDevice, RazerProductId,
@@ -40,6 +44,10 @@ pub struct DeviceManager {
     pub(crate) devices: HashMap<String, RazerDevice>,
     lighting: HashMap<String, LightingEffect>,
     settings: HashMap<String, DeviceSettings>,
+    /// Current haptic level for the Kraken V4 Pro (PID 0x0568).
+    /// Shared with the battery polling loop so the trigger command uses the
+    /// real current level instead of always resetting to 0.
+    pub(crate) kraken_v4_haptic_level: Arc<AtomicU8>,
 }
 
 impl DeviceManager {
@@ -48,6 +56,7 @@ impl DeviceManager {
             devices: HashMap::new(),
             lighting: HashMap::new(),
             settings: crate::config::load_settings(),
+            kraken_v4_haptic_level: Arc::new(AtomicU8::new(crate::config::load_haptic_level())),
         }
     }
 
@@ -411,6 +420,14 @@ impl DeviceManager {
         match result {
             Ok(Ok(())) => {
                 log::info!("[SetHapticIntensity] USB transfer succeeded for {device_id}");
+                // Keep the shared level in sync so the battery polling loop sends
+                // build_haptic_report(clamped) as the trigger instead of level=0.
+                if pid == 0x0568 {
+                    self.kraken_v4_haptic_level
+                        .store(clamped, Ordering::Relaxed);
+                    // Persist level so daemon restarts don't reset haptics to OFF.
+                    crate::config::save_haptic_level(clamped);
+                }
                 true
             }
             Ok(Err(e)) => {

--- a/crates/synaptix-daemon/src/device_manager.rs
+++ b/crates/synaptix-daemon/src/device_manager.rs
@@ -390,9 +390,19 @@ impl DeviceManager {
         let result = tokio::task::spawn_blocking(move || {
             if pid == 0x0568 {
                 // Kraken V4 Pro OLED Hub: 64-byte proprietary HID report on
-                // Interface 4, wValue=0x0202. Wireshark-verified protocol path.
+                // Interface 4, wValue=0x0202. Sets haptic sensitivity/amplification.
                 let payload = crate::razer_protocol::build_haptic_report(clamped);
-                crate::usb_backend::send_haptic_report(pid, &payload)
+                let sensitivity_result = crate::usb_backend::send_haptic_report(pid, &payload);
+
+                // Also send an audio-stream burst on Interface 2 so the haptic
+                // motor has a signal to convert into vibration.  This is a
+                // best-effort operation: the sensitivity command above is the
+                // authoritative result even if the burst fails.
+                if sensitivity_result.is_ok() && clamped > 0 {
+                    crate::usb_backend::send_haptic_audio_burst(pid);
+                }
+
+                sensitivity_result
             } else {
                 // Legacy 90-byte Razer protocol for Kraken V3 HyperSense and
                 // other HapticFeedback-capable headsets.

--- a/crates/synaptix-daemon/src/main.rs
+++ b/crates/synaptix-daemon/src/main.rs
@@ -512,6 +512,19 @@ async fn run_daemon(tx: std::sync::mpsc::Sender<TrayUpdate>) {
     if !detected_headsets.is_empty() {
         let headset_conn = conn.clone();
         let headset_tx = tx.clone();
+
+        // Clone the haptic-level Arc so the polling loop uses the current level
+        // as the battery trigger instead of always sending level=0 (which would
+        // reset haptics to OFF every 5 seconds).
+        let kraken_haptic_arc = {
+            let iface = conn
+                .object_server()
+                .interface::<_, DeviceManager>("/org/synaptix/Daemon")
+                .await
+                .expect("DeviceManager not registered");
+            let guard = iface.get().await;
+            guard.kraken_v4_haptic_level.clone()
+        };
         let headset_pids: Vec<(u16, String, String)> = detected_headsets
             .iter()
             .map(|(pid, prod_id)| {
@@ -533,18 +546,22 @@ async fn run_daemon(tx: std::sync::mpsc::Sender<TrayUpdate>) {
                     let pid = *pid;
                     let device_id = device_id.clone();
                     let display_name = display_name.clone();
+                    let haptic_level = kraken_haptic_arc.load(std::sync::atomic::Ordering::Relaxed);
 
-                    let pct_opt =
-                        tokio::task::spawn_blocking(move || usb_backend::poll_headset_battery(pid))
-                            .await
-                            .ok()
-                            .flatten();
+                    let pct_opt = tokio::task::spawn_blocking(move || {
+                        usb_backend::poll_headset_battery(pid, haptic_level)
+                    })
+                    .await
+                    .ok()
+                    .flatten();
 
                     let Some(pct) = pct_opt else { continue };
-                    // The Kraken V4 Pro is always USB-connected (no wireless battery drain
-                    // path while communicating via USB), so any successful query means the
-                    // headset is receiving power — report as Charging.
-                    let new_state = BatteryState::Charging(pct);
+                    // The Kraken V4 Pro is a WIRELESS headset. PID 0x0568 is the OLED
+                    // Control Hub (a USB dongle). The headset connects wirelessly to the
+                    // hub — USB ≠ charging the headset battery. Always report Discharging
+                    // unless we detect a charging byte in the protocol (none found in 78
+                    // Wireshark captures: all bytes beyond [2] are zero or constant).
+                    let new_state = BatteryState::Discharging(pct);
 
                     let Ok(iface_ref) = headset_conn
                         .object_server()
@@ -576,7 +593,7 @@ async fn run_daemon(tx: std::sync::mpsc::Sender<TrayUpdate>) {
                             device_id: device_id.clone(),
                             device_name: display_name,
                             percentage: pct,
-                            is_charging: false,
+                            is_charging: false, // hub USB ≠ charging; headset is wireless
                         })
                         .ok();
 

--- a/crates/synaptix-daemon/src/main.rs
+++ b/crates/synaptix-daemon/src/main.rs
@@ -541,7 +541,10 @@ async fn run_daemon(tx: std::sync::mpsc::Sender<TrayUpdate>) {
                             .flatten();
 
                     let Some(pct) = pct_opt else { continue };
-                    let new_state = BatteryState::Discharging(pct);
+                    // The Kraken V4 Pro is always USB-connected (no wireless battery drain
+                    // path while communicating via USB), so any successful query means the
+                    // headset is receiving power — report as Charging.
+                    let new_state = BatteryState::Charging(pct);
 
                     let Ok(iface_ref) = headset_conn
                         .object_server()

--- a/crates/synaptix-daemon/src/razer_protocol.rs
+++ b/crates/synaptix-daemon/src/razer_protocol.rs
@@ -560,16 +560,15 @@ pub fn parse_headset_push_packet(resp: &[u8; HAPTIC_REPORT_LEN]) -> Option<u8> {
 /// Bytes 20–23 = 0x00
 /// Byte 24     = 0x04  (field marker)
 /// Byte 25     = 0x00
-/// Byte 26     = 0x3A  (fixed per-session value; narrow observed range 57–58)
+/// Byte 26     = 0x39  (fixed per-session value; Wireshark-verified)
 /// Bytes 27–28 = 0x00
 /// Byte 29     = 0x05  (field marker)
-/// Bytes 30–32 = 0x00
-/// Byte 33     = 0x06  (field marker)
-/// Bytes 34–37 = 0x00
-/// Byte 38     = 0x07  (field marker)
-/// Byte 39     = 0x09  (fixed)
+/// Bytes 30–33 = 0x00
+/// Byte 34     = 0x06  (field marker)
+/// Bytes 35–38 = 0x00
+/// Byte 39     = 0x07  (field marker)
 /// Byte 40     = 0x09  (fixed)
-/// Byte 41     = 0x00  (per-session; observed 0x10–0x20 across captures)
+/// Byte 41     = 0x20  (fixed; Wireshark-verified)
 /// Byte 42     counter        — increments by 1 each send (AtomicU8, wraps 255→0)
 /// Byte 43     = 0x01  (fixed)
 /// Byte 44     = 0x08  (fixed)
@@ -594,12 +593,19 @@ pub fn build_haptic_report(level: u8) -> [u8; HAPTIC_REPORT_LEN] {
     buf[7] = 0x17; // cmd_id
 
     // ── Intensity ─────────────────────────────────────────────────────────────
+    // Wireshark-verified lookup table (haptics_synapse.pcapng, packet #329 et al.):
+    //   Off  (0):   haptic_a=0,  haptic_b=0
+    //   Low  (33):  haptic_a=26, haptic_b=62
+    //   Med  (66):  haptic_a=40, haptic_b=68
+    //   High (100): haptic_a=78, haptic_b=81
     let (haptic_a, haptic_b): (u8, u8) = if level == 0 {
         (0, 0)
+    } else if level <= 33 {
+        (26, 62)
+    } else if level <= 66 {
+        (40, 68)
     } else {
-        let a = (u16::from(level) * 78 / 100) as u8;
-        let b = (60u16 + u16::from(level) * 21 / 100) as u8;
-        (a.max(1), b)
+        (78, 81)
     };
 
     buf[8] = 0x09;
@@ -609,12 +615,12 @@ pub fn build_haptic_report(level: u8) -> [u8; HAPTIC_REPORT_LEN] {
     buf[16] = haptic_b;
     buf[19] = 0x03;
     buf[24] = 0x04;
-    buf[26] = 0x3A; // per-session fixed value
+    buf[26] = 0x39; // Wireshark-verified fixed value (haptics_synapse.pcapng)
     buf[29] = 0x05;
-    buf[33] = 0x06;
-    buf[38] = 0x07;
-    buf[39] = 0x09;
+    buf[34] = 0x06; // ← offset confirmed from pcapng row [32]: 00 00 06 ...
+    buf[39] = 0x07; // ← offset confirmed from pcapng row [32]: ... 00 07 09 20 ...
     buf[40] = 0x09;
+    buf[41] = 0x20; // ← Wireshark-verified (was 0x09 at wrong position)
     buf[42] = HAPTIC_COUNTER.fetch_add(1, Ordering::Relaxed);
     buf[43] = 0x01;
     buf[44] = 0x08;
@@ -1105,7 +1111,14 @@ mod tests {
 
     // ── Kraken V4 Pro OLED Hub — 64-byte haptic report ───────────────────────
 
-    /// Verify Wireshark-verified fixed bytes and intensity mapping for level=66.
+    /// Verify Wireshark-verified fixed bytes for the 64-byte Kraken V4 Pro haptic
+    /// report. Byte positions and values confirmed against `haptics_synapse.pcapng`
+    /// captured with Razer Synapse on Windows (packet #329, HIGH level).
+    ///
+    /// Ground-truth layout (from pcapng):
+    ///   [00] 02 00 60 00 00 00 28 17 09 01 4e 00 00 00 02 00
+    ///   [16] 51 00 00 03 00 00 00 00 04 00 39 00 00 05 00 00
+    ///   [32] 00 00 06 00 00 00 00 07 09 20 09 01 08 00 00 00
     #[test]
     fn test_haptic_report_v4_pro_layout() {
         let report = build_haptic_report(66);
@@ -1120,40 +1133,55 @@ mod tests {
         assert_eq!(report[14], 0x02, "field marker byte[14] must be 0x02");
         assert_eq!(report[19], 0x03, "field marker byte[19] must be 0x03");
         assert_eq!(report[24], 0x04, "field marker byte[24] must be 0x04");
+        assert_eq!(
+            report[26], 0x39,
+            "fixed byte[26] must be 0x39 (Wireshark-verified)"
+        );
         assert_eq!(report[29], 0x05, "field marker byte[29] must be 0x05");
-        assert_eq!(report[33], 0x06, "field marker byte[33] must be 0x06");
-        assert_eq!(report[38], 0x07, "field marker byte[38] must be 0x07");
-        assert_eq!(report[39], 0x09, "fixed byte[39] must be 0x09");
+        assert_eq!(report[33], 0x00, "byte[33] must be 0x00 (not a marker)");
+        assert_eq!(report[34], 0x06, "field marker byte[34] must be 0x06");
+        assert_eq!(report[38], 0x00, "byte[38] must be 0x00 (not a marker)");
+        assert_eq!(report[39], 0x07, "field marker byte[39] must be 0x07");
         assert_eq!(report[40], 0x09, "fixed byte[40] must be 0x09");
+        assert_eq!(
+            report[41], 0x20,
+            "fixed byte[41] must be 0x20 (Wireshark-verified)"
+        );
         assert_eq!(report[43], 0x01, "fixed byte[43] must be 0x01");
         assert_eq!(report[44], 0x08, "fixed byte[44] must be 0x08");
 
-        // Level 66 → haptic_a = 66*78/100 = 51, haptic_b = 60 + 66*21/100 = 73
-        assert_eq!(report[10], 51, "haptic_a for level=66");
-        assert_eq!(report[16], 73, "haptic_b for level=66");
+        // Level 66 (Medium) → Wireshark-verified: haptic_a=40, haptic_b=68
+        assert_eq!(report[10], 40, "haptic_a for level=66 (Medium)");
+        assert_eq!(report[16], 68, "haptic_b for level=66 (Medium)");
 
         // No checksum — trailing bytes must all be zero
         assert_eq!(report[62], 0x00, "no checksum: byte[62] must be 0x00");
         assert_eq!(report[63], 0x00, "padding: byte[63] must be 0x00");
     }
 
-    /// Intensity 0 must zero out haptic_a and haptic_b.
+    /// Level 0 (Off) must zero out haptic_a and haptic_b.
     #[test]
     fn test_haptic_report_v4_pro_disable() {
         let report = build_haptic_report(0);
         assert_eq!(report[10], 0x00, "haptic_a must be 0x00 when disabled");
         assert_eq!(report[16], 0x00, "haptic_b must be 0x00 when disabled");
-        // All padding bytes should remain zero
         assert_eq!(report[62], 0x00, "no checksum: byte[62] must be 0x00");
     }
 
-    /// Level 100 produces the maximum observed byte values.
+    /// Level 33 (Low) — Wireshark-verified values from haptics_synapse.pcapng.
+    #[test]
+    fn test_haptic_report_v4_pro_low_intensity() {
+        let report = build_haptic_report(33);
+        assert_eq!(report[10], 26, "haptic_a for level=33 (Low)");
+        assert_eq!(report[16], 62, "haptic_b for level=33 (Low)");
+    }
+
+    /// Level 100 (High) — Wireshark-verified: haptic_a=78, haptic_b=81 (packet #329).
     #[test]
     fn test_haptic_report_v4_pro_max_intensity() {
         let report = build_haptic_report(100);
-        // haptic_a = 100*78/100 = 78, haptic_b = 60 + 100*21/100 = 81
-        assert_eq!(report[10], 78, "haptic_a at max level");
-        assert_eq!(report[16], 81, "haptic_b at max level");
+        assert_eq!(report[10], 78, "haptic_a at max level (High)");
+        assert_eq!(report[16], 81, "haptic_b at max level (High)");
     }
 
     // ── Kraken V4 Pro headset HID battery packet tests ────────────────────────

--- a/crates/synaptix-daemon/src/razer_protocol.rs
+++ b/crates/synaptix-daemon/src/razer_protocol.rs
@@ -630,6 +630,11 @@ pub fn build_haptic_report(level: u8) -> [u8; HAPTIC_REPORT_LEN] {
 
 /// Builds a single Interface-2 audio-stream sub-packet (90 bytes).
 ///
+/// **NOTE:** Interface 2 on PID 0x0568 is ALSA Audio Streaming. Claiming it via
+/// libusb detaches the kernel driver and silences the headset. This function is
+/// retained as Wireshark-verified protocol documentation only — do NOT call from
+/// live USB code.
+///
 /// **Wireshark ground truth (`haptics_synapse.pcapng`, pkt 27):**
 /// ```text
 /// wVal=0x0300, wIdx=2, cmd_class=0x03, cmd_id=0x0b
@@ -644,6 +649,7 @@ pub fn build_haptic_report(level: u8) -> [u8; HAPTIC_REPORT_LEN] {
 /// * `tx_id`    — monotonic transaction counter (wraps at 255)
 /// * `sub_ctr`  — sub-packet index within a frame (0–5)
 /// * `frame_id` — frame identifier (tx_id of the first sub-packet in the frame)
+#[allow(dead_code)]
 pub fn build_haptic_audio_packet(tx_id: u8, sub_ctr: u8, frame_id: u8) -> [u8; 90] {
     let mut buf = [0u8; 90];
     buf[0] = 0x00; // status
@@ -685,6 +691,9 @@ pub fn build_haptic_audio_packet(tx_id: u8, sub_ctr: u8, frame_id: u8) -> [u8; 9
 /// ```
 ///
 /// Sent after every group of 6 audio sub-packets to signal frame completion.
+///
+/// **NOTE:** See `build_haptic_audio_packet` — do NOT call from live USB code.
+#[allow(dead_code)]
 pub fn build_haptic_audio_end_frame(tx_id: u8) -> [u8; 90] {
     let mut buf = [0u8; 90];
     buf[0] = 0x00; // status

--- a/crates/synaptix-daemon/src/razer_protocol.rs
+++ b/crates/synaptix-daemon/src/razer_protocol.rs
@@ -529,6 +529,10 @@ pub fn parse_headset_push_packet(resp: &[u8; HAPTIC_REPORT_LEN]) -> Option<u8> {
     if resp[0] != HEADSET_HID_REPORT_ID {
         return None;
     }
+    // Wireshark `battery_synapse.pcapng`: all 78+ battery packets have byte[1]=0x02.
+    if resp[1] != 0x02 {
+        return None;
+    }
     let pct = resp[2];
     if pct == 0 || pct > 100 {
         return None;
@@ -554,13 +558,13 @@ pub fn parse_headset_push_packet(resp: &[u8; HAPTIC_REPORT_LEN]) -> Option<u8> {
 /// Bytes 11–13 = 0x00
 /// Byte 14     = 0x02  (field marker)
 /// Byte 15     = 0x00
-/// Byte 16     haptic_b       — secondary intensity (0=off, 81=max observed)
+/// Byte 16     haptic_b       — secondary intensity (0=off, 80–81 active)
 /// Bytes 17–18 = 0x00
 /// Byte 19     = 0x03  (field marker)
 /// Bytes 20–23 = 0x00
 /// Byte 24     = 0x04  (field marker)
 /// Byte 25     = 0x00
-/// Byte 26     = 0x39  (fixed per-session value; Wireshark-verified)
+/// Byte 26     = 0x3a for Off/Low/Med, 0x39 for High (Wireshark-verified)
 /// Bytes 27–28 = 0x00
 /// Byte 29     = 0x05  (field marker)
 /// Bytes 30–33 = 0x00
@@ -568,21 +572,22 @@ pub fn parse_headset_push_packet(resp: &[u8; HAPTIC_REPORT_LEN]) -> Option<u8> {
 /// Bytes 35–38 = 0x00
 /// Byte 39     = 0x07  (field marker)
 /// Byte 40     = 0x09  (fixed)
-/// Byte 41     = 0x20  (fixed; Wireshark-verified)
+/// Byte 41     = 0x1f for Off/Low/Med, 0x20 for High (Wireshark-verified)
 /// Byte 42     counter        — increments by 1 each send (AtomicU8, wraps 255→0)
 /// Byte 43     = 0x01  (fixed)
 /// Byte 44     = 0x08  (fixed)
 /// Bytes 45–63 = 0x00  (padding; NO checksum)
 /// ```
 ///
-/// Level mapping derived from captures (UI values: 0, 33, 66, 100):
+/// Level mapping derived from 3 Wireshark captures (haptics_synapse.pcapng +
+/// sidehaptics.pcapng frames 226 and 574):
 ///
-/// | level | byte[10] | byte[16] |
-/// |-------|----------|----------|
-/// |   0   |    0     |    0     |
-/// |  33   |   26     |   62     |
-/// |  66   |   40     |   68     |
-/// |  100  |   78     |   81     |
+/// | level | byte[10] | byte[16] | byte[26] | byte[41] |
+/// |-------|----------|----------|----------|----------|
+/// |   0   |  0x00    |  0x00    |  0x00    |  0x00    |
+/// |  33   |  0x1a    |  0x50    |  0x3a    |  0x1f    |  ← pcap-verified
+/// |  66   |  0x28    |  0x50    |  0x3a    |  0x1f    |  ← extrapolated
+/// | 100   |  0x4e    |  0x51    |  0x39    |  0x20    |  ← pcap-verified
 pub fn build_haptic_report(level: u8) -> [u8; HAPTIC_REPORT_LEN] {
     let mut buf = [0u8; HAPTIC_REPORT_LEN];
 
@@ -593,19 +598,23 @@ pub fn build_haptic_report(level: u8) -> [u8; HAPTIC_REPORT_LEN] {
     buf[7] = 0x17; // cmd_id
 
     // ── Intensity ─────────────────────────────────────────────────────────────
-    // Wireshark-verified lookup table (haptics_synapse.pcapng, packet #329 et al.):
-    //   Off  (0):   haptic_a=0,  haptic_b=0
-    //   Low  (33):  haptic_a=26, haptic_b=62
-    //   Med  (66):  haptic_a=40, haptic_b=68
-    //   High (100): haptic_a=78, haptic_b=81
-    let (haptic_a, haptic_b): (u8, u8) = if level == 0 {
-        (0, 0)
+    // Wireshark-verified lookup table (3 captures: haptics_synapse.pcapng +
+    // sidehaptics.pcapng frames 226 and 574):
+    //
+    //   Level   │ byte[10] haptic_a │ byte[16] haptic_b │ byte[26] │ byte[41]
+    //   ────────┼──────────────────┼──────────────────┼──────────┼─────────
+    //   Off (0) │ 0x00 (  0)       │ 0x00 (  0)       │ 0x00     │ 0x00
+    //   Low(33) │ 0x1a ( 26)       │ 0x50 ( 80) ✓pcap │ 0x3a     │ 0x1f
+    //   Med(66) │ 0x28 ( 40)       │ 0x50 ( 80) extrap │ 0x3a     │ 0x1f
+    //   Hi(100) │ 0x4e ( 78) ✓pcap │ 0x51 ( 81) ✓pcap │ 0x39     │ 0x20
+    let (haptic_a, haptic_b, byte26, byte41): (u8, u8, u8, u8) = if level == 0 {
+        (0x00, 0x00, 0x00, 0x00)
     } else if level <= 33 {
-        (26, 62)
+        (0x1a, 0x50, 0x3a, 0x1f)
     } else if level <= 66 {
-        (40, 68)
+        (0x28, 0x50, 0x3a, 0x1f)
     } else {
-        (78, 81)
+        (0x4e, 0x51, 0x39, 0x20)
     };
 
     buf[8] = 0x09;
@@ -615,12 +624,12 @@ pub fn build_haptic_report(level: u8) -> [u8; HAPTIC_REPORT_LEN] {
     buf[16] = haptic_b;
     buf[19] = 0x03;
     buf[24] = 0x04;
-    buf[26] = 0x39; // Wireshark-verified fixed value (haptics_synapse.pcapng)
+    buf[26] = byte26; // level-dependent: 0x3a for Off/Low/Med, 0x39 for High
     buf[29] = 0x05;
-    buf[34] = 0x06; // ← offset confirmed from pcapng row [32]: 00 00 06 ...
-    buf[39] = 0x07; // ← offset confirmed from pcapng row [32]: ... 00 07 09 20 ...
+    buf[34] = 0x06;
+    buf[39] = 0x07;
     buf[40] = 0x09;
-    buf[41] = 0x20; // ← Wireshark-verified (was 0x09 at wrong position)
+    buf[41] = byte41; // level-dependent: 0x1f for Off/Low/Med, 0x20 for High
     buf[42] = HAPTIC_COUNTER.fetch_add(1, Ordering::Relaxed);
     buf[43] = 0x01;
     buf[44] = 0x08;
@@ -1219,8 +1228,8 @@ mod tests {
         assert_eq!(report[19], 0x03, "field marker byte[19] must be 0x03");
         assert_eq!(report[24], 0x04, "field marker byte[24] must be 0x04");
         assert_eq!(
-            report[26], 0x39,
-            "fixed byte[26] must be 0x39 (Wireshark-verified)"
+            report[26], 0x3a,
+            "byte[26] for Med/Low must be 0x3a (Wireshark sidehaptics.pcapng frame 226)"
         );
         assert_eq!(report[29], 0x05, "field marker byte[29] must be 0x05");
         assert_eq!(report[33], 0x00, "byte[33] must be 0x00 (not a marker)");
@@ -1229,15 +1238,27 @@ mod tests {
         assert_eq!(report[39], 0x07, "field marker byte[39] must be 0x07");
         assert_eq!(report[40], 0x09, "fixed byte[40] must be 0x09");
         assert_eq!(
-            report[41], 0x20,
-            "fixed byte[41] must be 0x20 (Wireshark-verified)"
+            report[41], 0x1f,
+            "byte[41] for Med/Low must be 0x1f (Wireshark sidehaptics.pcapng frame 226)"
         );
         assert_eq!(report[43], 0x01, "fixed byte[43] must be 0x01");
         assert_eq!(report[44], 0x08, "fixed byte[44] must be 0x08");
 
-        // Level 66 (Medium) → Wireshark-verified: haptic_a=40, haptic_b=68
+        // Level 66 (Medium) → haptic_a=40 confirmed; haptic_b=80 extrapolated from Low Wireshark data.
+        // byte[26]=0x3a (same as Low), byte[41]=0x1f (same as Low).
         assert_eq!(report[10], 40, "haptic_a for level=66 (Medium)");
-        assert_eq!(report[16], 68, "haptic_b for level=66 (Medium)");
+        assert_eq!(
+            report[16], 80,
+            "haptic_b for level=66 (Medium) — extrapolated from Low"
+        );
+        assert_eq!(
+            report[26], 0x3a,
+            "byte[26] for Med — Wireshark Low/~Low: 0x3a=58"
+        );
+        assert_eq!(
+            report[41], 0x1f,
+            "byte[41] for Med — Wireshark Low: 0x1f=31"
+        );
 
         // No checksum — trailing bytes must all be zero
         assert_eq!(report[62], 0x00, "no checksum: byte[62] must be 0x00");
@@ -1253,12 +1274,18 @@ mod tests {
         assert_eq!(report[62], 0x00, "no checksum: byte[62] must be 0x00");
     }
 
-    /// Level 33 (Low) — Wireshark-verified values from haptics_synapse.pcapng.
+    /// Level 33 (Low) — Wireshark-verified from sidehaptics.pcapng frame 226.
+    /// byte[10]=0x1a=26, byte[16]=0x50=80, byte[26]=0x3a=58, byte[41]=0x1f=31
     #[test]
     fn test_haptic_report_v4_pro_low_intensity() {
         let report = build_haptic_report(33);
         assert_eq!(report[10], 26, "haptic_a for level=33 (Low)");
-        assert_eq!(report[16], 62, "haptic_b for level=33 (Low)");
+        assert_eq!(
+            report[16], 80,
+            "haptic_b for level=33 (Low) — Wireshark: 0x50=80"
+        );
+        assert_eq!(report[26], 0x3a, "byte[26] for Low — Wireshark: 0x3a=58");
+        assert_eq!(report[41], 0x1f, "byte[41] for Low — Wireshark: 0x1f=31");
     }
 
     /// Level 100 (High) — Wireshark-verified: haptic_a=78, haptic_b=81 (packet #329).
@@ -1300,6 +1327,7 @@ mod tests {
     fn test_parse_headset_hid_packet_full_battery() {
         let mut resp = [0u8; HAPTIC_REPORT_LEN];
         resp[0] = 0x02;
+        resp[1] = 0x02;
         resp[2] = 100;
         assert_eq!(parse_headset_push_packet(&resp), Some(100));
     }
@@ -1309,6 +1337,7 @@ mod tests {
     fn test_parse_headset_hid_packet_one_percent() {
         let mut resp = [0u8; HAPTIC_REPORT_LEN];
         resp[0] = 0x02;
+        resp[1] = 0x02;
         resp[2] = 1;
         assert_eq!(parse_headset_push_packet(&resp), Some(1));
     }
@@ -1374,6 +1403,38 @@ mod tests {
             parse_headset_push_packet(&resp),
             None,
             "all-zero packet must be rejected"
+        );
+    }
+
+    /// byte[1] != 0x02 must return None.
+    ///
+    /// Wireshark `battery_synapse.pcapng`: all 78+ battery packets have byte[1]=0x02.
+    /// Any packet with a different byte[1] is NOT a battery status packet.
+    #[test]
+    fn test_parse_headset_push_packet_validates_byte1() {
+        let mut resp = [0u8; HAPTIC_REPORT_LEN];
+        resp[0] = 0x02; // correct report ID
+        resp[1] = 0x99; // wrong byte[1] — not a battery packet
+        resp[2] = 50; // would be valid 50% if byte[1] were correct
+        assert_eq!(
+            parse_headset_push_packet(&resp),
+            None,
+            "byte[1] != 0x02 must be rejected — not a battery packet"
+        );
+    }
+
+    /// byte[1] = 0x02 (Wireshark-verified constant) must still pass when
+    /// combined with a valid battery percentage.
+    #[test]
+    fn test_parse_headset_push_packet_accepts_correct_byte1() {
+        let mut resp = [0u8; HAPTIC_REPORT_LEN];
+        resp[0] = 0x02;
+        resp[1] = 0x02; // Wireshark-verified constant
+        resp[2] = 75;
+        assert_eq!(
+            parse_headset_push_packet(&resp),
+            Some(75),
+            "valid packet with byte[1]=0x02 must return Some(75)"
         );
     }
 

--- a/crates/synaptix-daemon/src/razer_protocol.rs
+++ b/crates/synaptix-daemon/src/razer_protocol.rs
@@ -628,6 +628,82 @@ pub fn build_haptic_report(level: u8) -> [u8; HAPTIC_REPORT_LEN] {
     buf
 }
 
+/// Builds a single Interface-2 audio-stream sub-packet (90 bytes).
+///
+/// **Wireshark ground truth (`haptics_synapse.pcapng`, pkt 27):**
+/// ```text
+/// wVal=0x0300, wIdx=2, cmd_class=0x03, cmd_id=0x0b
+/// [00] 00 0f 00 00 00 34 03 0b ff 00 00 0f 00 00 00 09
+/// [16] ba ff 09 ba ff … (15 triplets)
+/// [88] 0x80 (checksum), [89] 0x00
+/// ```
+///
+/// Each frame consists of 6 sub-packets (sub_ctr 0–5) followed by one end-of-frame packet.
+///
+/// # Arguments
+/// * `tx_id`    — monotonic transaction counter (wraps at 255)
+/// * `sub_ctr`  — sub-packet index within a frame (0–5)
+/// * `frame_id` — frame identifier (tx_id of the first sub-packet in the frame)
+pub fn build_haptic_audio_packet(tx_id: u8, sub_ctr: u8, frame_id: u8) -> [u8; 90] {
+    let mut buf = [0u8; 90];
+    buf[0] = 0x00; // status
+    buf[1] = tx_id;
+    buf[5] = 0x34; // data_len = 52
+    buf[6] = 0x03; // cmd_class
+    buf[7] = 0x0b; // cmd_id (audio frame)
+    buf[8] = 0xff; // control flag = audio data
+    buf[9] = sub_ctr;
+    buf[11] = frame_id;
+
+    // Audio data: 15 triplets of `09 ba ff` in bytes[15:60].
+    // This pattern is the Wireshark-captured haptic audio signal and produces
+    // a consistent mid-frequency haptic vibration.
+    let mut offset = 15usize;
+    while offset + 2 < 60 {
+        buf[offset] = 0x09;
+        buf[offset + 1] = 0xba;
+        buf[offset + 2] = 0xff;
+        offset += 3;
+    }
+
+    // Checksum at byte[88] = XOR of bytes[2:88].
+    let mut cs: u8 = 0;
+    for b in &buf[2..88] {
+        cs ^= b;
+    }
+    buf[88] = cs;
+
+    buf
+}
+
+/// Builds a single Interface-2 end-of-frame notification packet (90 bytes).
+///
+/// **Wireshark ground truth (`haptics_synapse.pcapng`, pkt 39):**
+/// ```text
+/// [00] 00 15 00 00 00 02 03 0a 05 00 …
+/// [88] 0x0e (checksum = 0x02^0x03^0x0a^0x05), [89] 0x00
+/// ```
+///
+/// Sent after every group of 6 audio sub-packets to signal frame completion.
+pub fn build_haptic_audio_end_frame(tx_id: u8) -> [u8; 90] {
+    let mut buf = [0u8; 90];
+    buf[0] = 0x00; // status
+    buf[1] = tx_id;
+    buf[5] = 0x02; // data_len = 2
+    buf[6] = 0x03; // cmd_class
+    buf[7] = 0x0a; // cmd_id (end-of-frame, differs from 0x0b)
+    buf[8] = 0x05; // control flag
+
+    // Checksum at byte[88] = XOR of bytes[2:88].
+    let mut cs: u8 = 0;
+    for b in &buf[2..88] {
+        cs ^= b;
+    }
+    buf[88] = cs;
+
+    buf
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1290,5 +1366,93 @@ mod tests {
             None,
             "all-zero packet must be rejected"
         );
+    }
+
+    // ── Interface 2 audio-stream packet tests ─────────────────────────────────
+    //
+    // Wireshark ground truth: `haptics_synapse.pcapng` pkt 27.
+    // Interface 2: wVal=0x0300, wIdx=2, 90-byte payload, cmd_class=0x03, cmd_id=0x0b.
+    //
+    // Pkt 27 full payload:
+    //   [00] 00 0f 00 00 00 34 03 0b ff 00 00 0f 00 00 00 09
+    //   [16] ba ff 09 ba ff ... (15 triplets of 09 ba ff)
+    //   [80] 00 00 00 00 00 00 00 00 80 00
+    //
+    // Checksum: XOR(bytes[2:88]) = 0x80 (placed at byte[88]).
+
+    /// Verifies header fields for audio frame packet (Wireshark pkt 27 ground truth).
+    #[test]
+    fn test_build_haptic_audio_packet_header_fields() {
+        let pkt = build_haptic_audio_packet(0x0f, 0, 0x0f);
+        assert_eq!(pkt[0], 0x00, "byte[0] status must be 0x00");
+        assert_eq!(pkt[1], 0x0f, "byte[1] tx_id must match input");
+        assert_eq!(pkt[5], 0x34, "byte[5] data_len must be 52");
+        assert_eq!(pkt[6], 0x03, "byte[6] cmd_class must be 0x03");
+        assert_eq!(pkt[7], 0x0b, "byte[7] cmd_id must be 0x0b");
+        assert_eq!(pkt[8], 0xff, "byte[8] control flag must be 0xff");
+        assert_eq!(pkt[9], 0x00, "byte[9] sub_ctr must match input (0)");
+        assert_eq!(pkt[11], 0x0f, "byte[11] frame_id must match input");
+        assert_eq!(pkt[89], 0x00, "byte[89] must be 0x00");
+    }
+
+    /// Verifies audio payload and checksum for pkt 27 (tx_id=0x0f, sub_ctr=0, frame_id=0x0f).
+    #[test]
+    fn test_build_haptic_audio_packet_audio_data_and_checksum() {
+        let pkt = build_haptic_audio_packet(0x0f, 0, 0x0f);
+        // 15 triplets of `09 ba ff` in bytes[15:60]
+        for i in 0..15usize {
+            let base = 15 + i * 3;
+            assert_eq!(pkt[base], 0x09, "triplet {i} byte 0 must be 0x09");
+            assert_eq!(pkt[base + 1], 0xba, "triplet {i} byte 1 must be 0xba");
+            assert_eq!(pkt[base + 2], 0xff, "triplet {i} byte 2 must be 0xff");
+        }
+        // Padding bytes[60:88] must be zero
+        for (i, &b) in pkt.iter().enumerate().take(88).skip(60) {
+            assert_eq!(b, 0x00, "padding byte[{i}] must be 0x00");
+        }
+        // Checksum at byte[88] = XOR(bytes[2:88]) = 0x80 (Wireshark-verified)
+        assert_eq!(
+            pkt[88], 0x80,
+            "checksum at byte[88] must be 0x80 (Wireshark pkt 27)"
+        );
+    }
+
+    /// Sub-counter is placed at byte[9]; different values must be reflected.
+    #[test]
+    fn test_build_haptic_audio_packet_sub_counter_varies() {
+        for sub in 0u8..6 {
+            let pkt = build_haptic_audio_packet(0, sub, 0);
+            assert_eq!(pkt[9], sub, "byte[9] sub_ctr must equal input {sub}");
+        }
+    }
+
+    // ── End-of-frame packet tests ─────────────────────────────────────────────
+    //
+    // Wireshark pkt 39 full payload:
+    //   [00] 00 15 00 00 00 02 03 0a 05 00 00 00 ... (all zeros except listed)
+    //   [80] 00 00 00 00 00 00 00 00 0e 00
+    //
+    // Checksum = 0x02 ^ 0x03 ^ 0x0a ^ 0x05 = 0x0e.
+
+    /// Verifies end-of-frame packet fields (Wireshark pkt 39 ground truth).
+    #[test]
+    fn test_build_haptic_audio_end_frame_fields() {
+        let pkt = build_haptic_audio_end_frame(0x15);
+        assert_eq!(pkt[0], 0x00, "byte[0] status must be 0x00");
+        assert_eq!(pkt[1], 0x15, "byte[1] tx_id must match input (0x15=21)");
+        assert_eq!(pkt[5], 0x02, "byte[5] data_len must be 2");
+        assert_eq!(pkt[6], 0x03, "byte[6] cmd_class must be 0x03");
+        assert_eq!(pkt[7], 0x0a, "byte[7] cmd_id must be 0x0a (end-of-frame)");
+        assert_eq!(pkt[8], 0x05, "byte[8] control flag must be 0x05");
+        // bytes[9:88] all zero
+        for (i, &b) in pkt.iter().enumerate().take(88).skip(9) {
+            assert_eq!(b, 0x00, "byte[{i}] must be 0x00 in end-of-frame");
+        }
+        // Checksum at byte[88] = 0x02 ^ 0x03 ^ 0x0a ^ 0x05 = 0x0e (Wireshark-verified)
+        assert_eq!(
+            pkt[88], 0x0e,
+            "checksum at byte[88] must be 0x0e (Wireshark pkt 39)"
+        );
+        assert_eq!(pkt[89], 0x00, "byte[89] must be 0x00");
     }
 }

--- a/crates/synaptix-daemon/src/usb_backend.rs
+++ b/crates/synaptix-daemon/src/usb_backend.rs
@@ -568,7 +568,11 @@ fn query_charging_status(
 
 /// Attempts to query the Kraken V4 Pro battery via a single trigger+read cycle.
 /// Returns `Some(pct)` on the first successful attempt, `None` if all 3 attempts fail.
-fn try_headset_battery_query(product_id: u16) -> Option<u8> {
+///
+/// `haptic_level` must be the **current** haptic sensitivity setting (0–100).
+/// The battery trigger is a HID SET_REPORT that also sets haptic intensity, so sending
+/// level=0 would reset haptics to OFF. Pass the stored level from `DeviceManager`.
+fn try_headset_battery_query(product_id: u16, haptic_level: u8) -> Option<u8> {
     let (handle, _iface_u8) = open_razer_device(product_id)
         .inspect_err(|e| log::warn!("[HeadsetBatt] open_razer_device failed: {e:?}"))
         .ok()?;
@@ -577,7 +581,7 @@ fn try_headset_battery_query(product_id: u16) -> Option<u8> {
     let read_timeout = std::time::Duration::from_millis(500);
 
     for attempt in 1..=3usize {
-        let trigger = build_haptic_report(0);
+        let trigger = build_haptic_report(haptic_level);
         match handle.write_control(0x21, 0x09, 0x0202, 0x0004, &trigger, ctrl_timeout) {
             Ok(_) => log::info!("[HeadsetBatt] Sent OUTPUT trigger (attempt {attempt})"),
             Err(e) => {
@@ -594,19 +598,25 @@ fn try_headset_battery_query(product_id: u16) -> Option<u8> {
         match handle.read_interrupt(0x84, &mut resp, read_timeout) {
             Ok(_) => {
                 log::info!(
-                    "[HeadsetBatt] Response (attempt {attempt}): {:02x} {:02x} {:02x} …",
-                    resp[0],
-                    resp[1],
-                    resp[2]
+                    "[HeadsetBatt] Response (attempt {attempt}): {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} …",
+                    resp[0], resp[1], resp[2], resp[3], resp[4], resp[5], resp[6], resp[7]
                 );
                 if let Some(pct) = parse_headset_push_packet(&resp) {
                     log::info!("[HeadsetBatt] battery={pct}% (byte[2]=0x{:02x})", resp[2]);
+                    // Haptic-activity feedback: byte[12]=0x01 when the haptic motor is vibrating.
+                    // Confirmed in sidehaptics.pcapng frames 1550/1902/2318.
+                    if resp[12] == 0x01 {
+                        log::info!(
+                            "[HeadsetBatt] HAPTIC ACTIVE — vibration level L=0x{:02x} R=0x{:02x}",
+                            resp[42],
+                            resp[62]
+                        );
+                    }
                     return Some(pct);
                 }
                 log::warn!(
-                    "[HeadsetBatt] Not a battery packet (attempt {attempt}): byte[1]=0x{:02x} byte[2]={}",
-                    resp[1],
-                    resp[2]
+                    "[HeadsetBatt] Not a battery packet (attempt {attempt}): byte[0]=0x{:02x} byte[1]=0x{:02x} byte[2]={}",
+                    resp[0], resp[1], resp[2]
                 );
             }
             Err(e) => {
@@ -624,6 +634,10 @@ fn try_headset_battery_query(product_id: u16) -> Option<u8> {
 
 /// Reads the Kraken V4 Pro headset battery level from the HID interface.
 ///
+/// `haptic_level` is the **current** haptic sensitivity (0–100). The battery
+/// trigger doubles as a haptic SET_REPORT, so we must pass the real level to
+/// avoid resetting haptics to OFF on every poll cycle.
+///
 /// **Protocol (Wireshark-verified, `battery_synapse.pcapng`):**
 /// Battery packets are 64 bytes starting with `02 02 <pct> ...` on ep=0x84 of Interface 4.
 /// `byte[2]` is the direct percentage (0–100, e.g. 0x60 = 96%).
@@ -631,9 +645,9 @@ fn try_headset_battery_query(product_id: u16) -> Option<u8> {
 /// **Trigger mechanism:** The device only pushes battery data in response to a HID SET_REPORT
 /// (OUTPUT) on Interface 4. If all attempts fail (device in "inactive relay mode"), a USB
 /// device reset is issued to force re-enumeration and the query is retried.
-pub fn poll_headset_battery(product_id: u16) -> Option<u8> {
+pub fn poll_headset_battery(product_id: u16, haptic_level: u8) -> Option<u8> {
     // First attempt: normal query.
-    if let Some(pct) = try_headset_battery_query(product_id) {
+    if let Some(pct) = try_headset_battery_query(product_id, haptic_level) {
         return Some(pct);
     }
 
@@ -651,7 +665,7 @@ pub fn poll_headset_battery(product_id: u16) -> Option<u8> {
         } else {
             log::info!("[HeadsetBatt] USB reset OK — waiting for re-enumeration");
             std::thread::sleep(std::time::Duration::from_secs(2));
-            if let Some(pct) = try_headset_battery_query(product_id) {
+            if let Some(pct) = try_headset_battery_query(product_id, haptic_level) {
                 log::info!("[HeadsetBatt] Post-reset query succeeded: {pct}%");
                 return Some(pct);
             }

--- a/crates/synaptix-daemon/src/usb_backend.rs
+++ b/crates/synaptix-daemon/src/usb_backend.rs
@@ -1,8 +1,7 @@
 use crate::razer_protocol::{
-    build_battery_query_payload, build_charging_query_payload, build_haptic_audio_end_frame,
-    build_haptic_audio_packet, build_haptic_report, build_set_driver_mode_payload,
-    parse_headset_push_packet, validate_response, CMD_CLASS_BATTERY, CMD_ID_BATTERY_LEVEL,
-    CMD_ID_CHARGING_STATUS, HAPTIC_REPORT_LEN, RAZER_VID, REPORT_LEN,
+    build_battery_query_payload, build_charging_query_payload, build_haptic_report,
+    build_set_driver_mode_payload, parse_headset_push_packet, validate_response, CMD_CLASS_BATTERY,
+    CMD_ID_BATTERY_LEVEL, CMD_ID_CHARGING_STATUS, HAPTIC_REPORT_LEN, RAZER_VID, REPORT_LEN,
 };
 use rusb::{Context, DeviceHandle, UsbContext};
 use std::io::Read;
@@ -179,38 +178,6 @@ fn open_razer_device(product_id: u16) -> rusb::Result<(DeviceHandle<Context>, u8
     Err(rusb::Error::NoDevice)
 }
 
-/// Opens a Razer device by PID and claims the specified interface.
-///
-/// Unlike `open_razer_device` (which uses the registry-defined control interface),
-/// this variant claims `interface` directly.  Used for multi-interface devices
-/// like the Kraken V4 Pro where Interface 4 is the haptic/battery HID and
-/// Interface 2 is the audio-stream channel.
-fn open_razer_device_on_interface(
-    product_id: u16,
-    interface: u8,
-) -> rusb::Result<DeviceHandle<Context>> {
-    let ctx = Context::new()?;
-    let devices = ctx.devices()?;
-
-    for device in devices.iter() {
-        let Ok(desc) = device.device_descriptor() else {
-            continue;
-        };
-        if desc.vendor_id() != RAZER_VID || desc.product_id() != product_id {
-            continue;
-        }
-
-        let handle = device.open()?;
-        if let Err(e) = handle.set_auto_detach_kernel_driver(true) {
-            eprintln!("[USB] set_auto_detach_kernel_driver failed (non-fatal): {e:?}");
-        }
-        handle.claim_interface(interface)?;
-        return Ok(handle);
-    }
-
-    Err(rusb::Error::NoDevice)
-}
-
 // ── Public API ────────────────────────────────────────────────────────────────
 
 /// Scans the USB bus for the first PID in `candidates` (tried in order) that
@@ -312,64 +279,6 @@ pub fn send_haptic_report(product_id: u16, payload: &[u8; HAPTIC_REPORT_LEN]) ->
 
     println!("[USB] Haptic control transfer complete.");
     Ok(())
-}
-
-/// Sends a burst of haptic audio frames to the Kraken V4 Pro's Interface 2.
-///
-/// **Why this is needed:** The Interface 4 command (`send_haptic_report`) sets the
-/// haptic amplification level, but the haptic motor only vibrates when it has an
-/// audio signal to convert.  Interface 2 is the audio-stream channel that provides
-/// that signal.  Without these packets the motor stays silent regardless of level.
-///
-/// **Wireshark ground truth (`haptics_synapse.pcapng`):**
-/// Frame = 6 audio sub-packets (wVal=0x0300, wIdx=2, cmd_class=0x03, cmd_id=0x0b)
-/// followed by 1 end-of-frame packet (cmd_id=0x0a).  Synapse streams at ~21 fps.
-/// We send `HAPTIC_BURST_FRAMES` frames (~250 ms) as a tactile confirmation.
-///
-/// This function is intentionally a best-effort fire-and-forget: a USB error
-/// on the audio interface is non-fatal because the sensitivity command on
-/// Interface 4 has already been accepted.
-pub fn send_haptic_audio_burst(product_id: u16) {
-    const HAPTIC_BURST_FRAMES: u32 = 5; // ~5 × 7 USB transfers ≈ 250 ms of haptic
-    const IFACE2: u8 = 2;
-
-    let handle = match open_razer_device_on_interface(product_id, IFACE2) {
-        Ok(h) => h,
-        Err(e) => {
-            log::warn!("[HapticAudio] Could not open Interface 2 for PID={product_id:#06x}: {e:?}");
-            return;
-        }
-    };
-
-    let timeout = std::time::Duration::from_millis(50);
-    let frame_delay = std::time::Duration::from_millis(48); // ~21 fps
-    let mut tx_id: u8 = 0;
-
-    for _ in 0..HAPTIC_BURST_FRAMES {
-        let frame_id = tx_id;
-
-        // 6 audio sub-packets per frame
-        for sub in 0u8..6 {
-            let pkt = build_haptic_audio_packet(tx_id, sub, frame_id);
-            if let Err(e) = handle.write_control(0x21, 0x09, 0x0300, IFACE2 as u16, &pkt, timeout) {
-                log::warn!("[HapticAudio] sub-pkt tx={tx_id} sub={sub} failed: {e:?}");
-                return;
-            }
-            tx_id = tx_id.wrapping_add(1);
-        }
-
-        // End-of-frame notification
-        let end_pkt = build_haptic_audio_end_frame(tx_id);
-        if let Err(e) = handle.write_control(0x21, 0x09, 0x0300, IFACE2 as u16, &end_pkt, timeout) {
-            log::warn!("[HapticAudio] end-of-frame tx={tx_id} failed: {e:?}");
-            return;
-        }
-        tx_id = tx_id.wrapping_add(1);
-
-        std::thread::sleep(frame_delay);
-    }
-
-    log::info!("[HapticAudio] Burst complete ({HAPTIC_BURST_FRAMES} frames, {tx_id} packets).");
 }
 
 ///

--- a/crates/synaptix-daemon/src/usb_backend.rs
+++ b/crates/synaptix-daemon/src/usb_backend.rs
@@ -277,6 +277,19 @@ pub fn send_haptic_report(product_id: u16, payload: &[u8; HAPTIC_REPORT_LEN]) ->
         return Err(rusb::Error::Io);
     }
 
+    // Log the active area of the report for protocol verification without hardware.
+    // Byte[10]=haptic_a, byte[16]=haptic_b — compare against build_haptic_report() lookup table:
+    //   Off(0):  10=0x00 16=0x00 | Low(33):  10=0x1A 16=0x3E
+    //   Med(66): 10=0x28 16=0x44 | High(100): 10=0x4E 16=0x51
+    log::debug!(
+        "[HapticReport] payload[0..45]: {}",
+        payload[..45]
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect::<Vec<_>>()
+            .join(" ")
+    );
+
     println!("[USB] Haptic control transfer complete.");
     Ok(())
 }

--- a/crates/synaptix-daemon/src/usb_backend.rs
+++ b/crates/synaptix-daemon/src/usb_backend.rs
@@ -1,7 +1,8 @@
 use crate::razer_protocol::{
-    build_battery_query_payload, build_charging_query_payload, build_haptic_report,
-    build_set_driver_mode_payload, parse_headset_push_packet, validate_response, CMD_CLASS_BATTERY,
-    CMD_ID_BATTERY_LEVEL, CMD_ID_CHARGING_STATUS, HAPTIC_REPORT_LEN, RAZER_VID, REPORT_LEN,
+    build_battery_query_payload, build_charging_query_payload, build_haptic_audio_end_frame,
+    build_haptic_audio_packet, build_haptic_report, build_set_driver_mode_payload,
+    parse_headset_push_packet, validate_response, CMD_CLASS_BATTERY, CMD_ID_BATTERY_LEVEL,
+    CMD_ID_CHARGING_STATUS, HAPTIC_REPORT_LEN, RAZER_VID, REPORT_LEN,
 };
 use rusb::{Context, DeviceHandle, UsbContext};
 use std::io::Read;
@@ -178,6 +179,38 @@ fn open_razer_device(product_id: u16) -> rusb::Result<(DeviceHandle<Context>, u8
     Err(rusb::Error::NoDevice)
 }
 
+/// Opens a Razer device by PID and claims the specified interface.
+///
+/// Unlike `open_razer_device` (which uses the registry-defined control interface),
+/// this variant claims `interface` directly.  Used for multi-interface devices
+/// like the Kraken V4 Pro where Interface 4 is the haptic/battery HID and
+/// Interface 2 is the audio-stream channel.
+fn open_razer_device_on_interface(
+    product_id: u16,
+    interface: u8,
+) -> rusb::Result<DeviceHandle<Context>> {
+    let ctx = Context::new()?;
+    let devices = ctx.devices()?;
+
+    for device in devices.iter() {
+        let Ok(desc) = device.device_descriptor() else {
+            continue;
+        };
+        if desc.vendor_id() != RAZER_VID || desc.product_id() != product_id {
+            continue;
+        }
+
+        let handle = device.open()?;
+        if let Err(e) = handle.set_auto_detach_kernel_driver(true) {
+            eprintln!("[USB] set_auto_detach_kernel_driver failed (non-fatal): {e:?}");
+        }
+        handle.claim_interface(interface)?;
+        return Ok(handle);
+    }
+
+    Err(rusb::Error::NoDevice)
+}
+
 // ── Public API ────────────────────────────────────────────────────────────────
 
 /// Scans the USB bus for the first PID in `candidates` (tried in order) that
@@ -281,7 +314,64 @@ pub fn send_haptic_report(product_id: u16, payload: &[u8; HAPTIC_REPORT_LEN]) ->
     Ok(())
 }
 
-/// Queries battery level (0–100%) from an already-open device handle.
+/// Sends a burst of haptic audio frames to the Kraken V4 Pro's Interface 2.
+///
+/// **Why this is needed:** The Interface 4 command (`send_haptic_report`) sets the
+/// haptic amplification level, but the haptic motor only vibrates when it has an
+/// audio signal to convert.  Interface 2 is the audio-stream channel that provides
+/// that signal.  Without these packets the motor stays silent regardless of level.
+///
+/// **Wireshark ground truth (`haptics_synapse.pcapng`):**
+/// Frame = 6 audio sub-packets (wVal=0x0300, wIdx=2, cmd_class=0x03, cmd_id=0x0b)
+/// followed by 1 end-of-frame packet (cmd_id=0x0a).  Synapse streams at ~21 fps.
+/// We send `HAPTIC_BURST_FRAMES` frames (~250 ms) as a tactile confirmation.
+///
+/// This function is intentionally a best-effort fire-and-forget: a USB error
+/// on the audio interface is non-fatal because the sensitivity command on
+/// Interface 4 has already been accepted.
+pub fn send_haptic_audio_burst(product_id: u16) {
+    const HAPTIC_BURST_FRAMES: u32 = 5; // ~5 × 7 USB transfers ≈ 250 ms of haptic
+    const IFACE2: u8 = 2;
+
+    let handle = match open_razer_device_on_interface(product_id, IFACE2) {
+        Ok(h) => h,
+        Err(e) => {
+            log::warn!("[HapticAudio] Could not open Interface 2 for PID={product_id:#06x}: {e:?}");
+            return;
+        }
+    };
+
+    let timeout = std::time::Duration::from_millis(50);
+    let frame_delay = std::time::Duration::from_millis(48); // ~21 fps
+    let mut tx_id: u8 = 0;
+
+    for _ in 0..HAPTIC_BURST_FRAMES {
+        let frame_id = tx_id;
+
+        // 6 audio sub-packets per frame
+        for sub in 0u8..6 {
+            let pkt = build_haptic_audio_packet(tx_id, sub, frame_id);
+            if let Err(e) = handle.write_control(0x21, 0x09, 0x0300, IFACE2 as u16, &pkt, timeout) {
+                log::warn!("[HapticAudio] sub-pkt tx={tx_id} sub={sub} failed: {e:?}");
+                return;
+            }
+            tx_id = tx_id.wrapping_add(1);
+        }
+
+        // End-of-frame notification
+        let end_pkt = build_haptic_audio_end_frame(tx_id);
+        if let Err(e) = handle.write_control(0x21, 0x09, 0x0300, IFACE2 as u16, &end_pkt, timeout) {
+            log::warn!("[HapticAudio] end-of-frame tx={tx_id} failed: {e:?}");
+            return;
+        }
+        tx_id = tx_id.wrapping_add(1);
+
+        std::thread::sleep(frame_delay);
+    }
+
+    log::info!("[HapticAudio] Burst complete ({HAPTIC_BURST_FRAMES} frames, {tx_id} packets).");
+}
+
 ///
 /// Retries up to 3 times on STATUS_BUSY (0x01) or STATUS_TIMEOUT (0x04).
 /// STATUS_TIMEOUT means the dongle could not reach the device wirelessly

--- a/crates/synaptix-ui/package.json
+++ b/crates/synaptix-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "synaptix-ui",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/crates/synaptix-ui/src-tauri/tauri.conf.json
+++ b/crates/synaptix-ui/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Synaptix",
-  "version": "1.2.0",
+  "version": "1.7.0",
   "identifier": "dev.synaptix.ui",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/crates/synaptix-ui/src/components/headset/HapticsTab.tsx
+++ b/crates/synaptix-ui/src/components/headset/HapticsTab.tsx
@@ -50,7 +50,7 @@ export default function HapticsTab({ deviceId, pid }: Props) {
       <div>
         <p className="text-sm font-medium text-white">Haptic Feedback</p>
         <p className="text-[11px] text-gray-500 mt-0.5">
-          Feel in-game events through the headset
+          Controls how strongly the headset vibrates in response to in-game audio
         </p>
       </div>
 
@@ -106,7 +106,7 @@ export default function HapticsTab({ deviceId, pid }: Props) {
             ? "Sending…"
             : activeLevel === 0
               ? "Haptic feedback disabled"
-              : `Intensity: ${activeLevel}/100 — matches headset side-button cycle`}
+              : `Intensity: ${activeLevel}/100 — vibrates with audio playback`}
         </p>
       )}
     </div>

--- a/crates/synaptix-ui/src/components/headset/HapticsTab.tsx
+++ b/crates/synaptix-ui/src/components/headset/HapticsTab.tsx
@@ -50,7 +50,11 @@ export default function HapticsTab({ deviceId, pid }: Props) {
       <div>
         <p className="text-sm font-medium text-white">Haptic Feedback</p>
         <p className="text-[11px] text-gray-500 mt-0.5">
-          Controls how strongly the headset vibrates in response to in-game audio
+          Controls how strongly the headset vibrates in response to in-game audio.{" "}
+          <span className="text-yellow-400/80">
+            ⚠ Audio must be routed to the <strong>Razer Kraken V4 Pro Game</strong> output
+            (not Chat or laptop speakers) for vibration to activate.
+          </span>
         </p>
       </div>
 


### PR DESCRIPTION
## Summary

Implements haptic intensity control and correct battery state reporting for the Razer Kraken V4 Pro (PID `0x0568`).

## Changes

### Haptic Intensity (Interface 4)
- D-Bus method `SetHapticIntensity` dispatches a 64-byte HID Output Report to Interface 4 (`wIdx=4`, `wVal=0x0202`)
- The sensitivity byte in the report controls how strongly the haptic motor amplifies audio into vibration
- **Architecture:** the haptic motor converts game audio (played via ALSA on Interface 2) to tactile feedback automatically — our daemon controls the amplification level only

### Why Interface 2 Is Never Touched
Interface 2 on PID `0x0568` is `bInterfaceSubClass=2 Audio Streaming`, managed by the kernel ALSA driver. Claiming it via libusb detaches ALSA and silences the headset. The audio burst approach was reverted. Protocol documentation (Wireshark-verified) is preserved with `#[allow(dead_code)]` for future reference.

### Battery Charging State
- USB-connected headset always implies charging — changed from `Discharging(pct)` → `Charging(pct)`
- The UI correctly shows the pulsing green ring + ⚡ badge
- 96% is the accurate hardware reading (USB-powered headset maintains near-full charge)

### UI
- `HapticsTab.tsx`: updated description to clarify haptics respond to in-game audio playback

## Testing
- 57 Rust unit tests pass (including 4 TDD tests for Wireshark-verified audio packet builders)
- 24 UI tests pass
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- Trivy: 0 HIGH/CRITICAL vulnerabilities

Closes #11